### PR TITLE
[patch] switch to codeship

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AWS This Week
 
 [![Node version](https://img.shields.io/badge/node-_8.10.0-green.svg?style=flat)](http://nodejs.org/download/)
-![Build Status](https://codebuild.ap-southeast-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiK3Nvb29qODlFalRKVE9rS2xWWjArSGZENVNsVUJKMHRodzhQTTYvQS9rTGpEam01QnAyaVNnTFQ5c2RFa0pVY3ZnRXduWlJsZlFxL1NBY3dTUFMvTEtZPSIsIml2UGFyYW1ldGVyU3BlYyI6ImU5RlB6d2xiZTd4M2hEV0ciLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+[![Codeship Status for jaypeng2015/aws-this-week](https://app.codeship.com/projects/9a012ef0-67ba-0136-cdd7-3e3131b5ecc0/status?branch=master)](https://app.codeship.com/projects/297691)
 [![Dependency Status](https://david-dm.org/jaypeng2015/aws-this-week/status.svg)](https://david-dm.org/jaypeng2015/aws-this-week)
 [![devDependency Status](https://david-dm.org/jaypeng2015/aws-this-week/dev-status.svg)](https://david-dm.org/jaypeng2015/aws-this-week?type=dev)
 
@@ -10,11 +10,11 @@ By default it runs at 00:00 (UTC) every Monday.
 
 ## Getting Started
 
-* git clone https://github.com/jaypeng2015/aws-this-week
-* cd aws-this-week
-* nvm install
-* npm install
-* npm test
+- git clone https://github.com/jaypeng2015/aws-this-week
+- cd aws-this-week
+- nvm install
+- npm install
+- npm test
 
 ## Configure your AWS credentials
 
@@ -22,13 +22,13 @@ You’ll need to configure your AWS dev account credentials if you want to deplo
 
 To create/retrieve your AWS security access keys:
 
-* Log into the AWS console, e.g. https://console.aws.amazon.com
-* Go to the [IAM](https://console.aws.amazon.com/iam/home) page
-* Click 'Users' from the side nav
-* Click your username in the list of Users
-* Click the 'Security credentials' tab
-* Click 'Create access key' under 'Access keys'
-* Click 'Download .csv file' to save a copy of the Access key ID and Secret access key
+- Log into the AWS console, e.g. https://console.aws.amazon.com
+- Go to the [IAM](https://console.aws.amazon.com/iam/home) page
+- Click 'Users' from the side nav
+- Click your username in the list of Users
+- Click the 'Security credentials' tab
+- Click 'Create access key' under 'Access keys'
+- Click 'Download .csv file' to save a copy of the Access key ID and Secret access key
 
 Note: You can't retrieve the secret access key later so either copy it now or save the `.csv` file to your computer.
 
@@ -66,10 +66,10 @@ export WEBHOOK_URL=https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/xxxxxxxx
 
 ## Deployment scripts
 
-* `npm run deploy` - deploy the function to your AWS account
-* `npm run remove` - remove the function stack from your AWS account
-* `npm run invoke` - invoke the function remotely
-* `npm run invoke-local` - invoke the function locally
+- `npm run deploy` - deploy the function to your AWS account
+- `npm run remove` - remove the function stack from your AWS account
+- `npm run invoke` - invoke the function remotely
+- `npm run invoke-local` - invoke the function locally
 
 ## Release
 
@@ -81,8 +81,8 @@ For more information please check [release-it](https://github.com/bpro/release-i
 
 ## Resources
 
-* [License (MIT)][license]
-* [Releases][releases]
+- [License (MIT)][license]
+- [Releases][releases]
 
 [license]: ./LICENSE
 [releases]: https://github.com/jaypeng2015/aws-this-week/releases

--- a/package.json
+++ b/package.json
@@ -40,5 +40,9 @@
     "release-it": "7.4.7",
     "serverless": "1.28.0",
     "serverless-prune-plugin": "1.3.1"
+  },
+  "engines": {
+    "node": "8.10.0",
+    "npm": "5.6.0"
   }
 }


### PR DESCRIPTION
Replace aws codebuild with codeship because the following command doesn't work:

```
git diff-index --name-only HEAD --exit-code
```

It should return nothing but on aws codebuild it lists all the files there, thus `releast-it.js` can't work.